### PR TITLE
Fixed crashes on ze_atix_panic_v1

### DIFF
--- a/addons/stripper/maps/ze_atix_panic_v1.cfg
+++ b/addons/stripper/maps/ze_atix_panic_v1.cfg
@@ -163,3 +163,21 @@ add:
 	"StartDisabled" "0"
 	"alternateticksfix" "0"
 }
+
+;Flagging a prop_dynamic as non-solid after its spawn can cause crashes from vphysics.dll
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"targetname" "heli_model"
+	}
+	delete:
+	{
+		"solid" "6"
+	}
+	insert:
+	{
+		"solid" "0"
+	}
+}


### PR DESCRIPTION
Explanation: Originally i thought the prop crashes because it spawns with solid 6 without a .phy model and that my fix is somehow not catching that. well i was wrong. the map itself breaks it, my plugin doesnt catch it because the model actually DOES have a proper .phy model, but the map sets that prop to solid 0 AFTER the prop already spawned (model already in solidity list as solid)