### PR TITLE
Added stripper to prevent crash for ze_twisted_valley_beta4_2

### DIFF
--- a/stripper/ze_twisted_valley_beta4_2.cfg
+++ b/stripper/ze_twisted_valley_beta4_2.cfg
@@ -1,0 +1,5 @@
+filter:
+{
+	"origin" "4950 -11493 -774"
+	"classname" "game_round_end"
+}


### PR DESCRIPTION
Removes an entity that kills teleport destination when the round ends, thus causing server to crash if any players touch the teleport trigger