### PR TITLE
editing cooldown in ze_backrooms_deathbed_t1f

### DIFF
--- a/entwatch/ze_backrooms_deathbed_t1f.cfg
+++ b/entwatch/ze_backrooms_deathbed_t1f.cfg
@@ -32,7 +32,7 @@
         "hammerid"          "112485"
         "mode"              "2"
         "maxuses"           "0"
-        "cooldown"          "55"
+        "cooldown"          "30"
     }
     "2"
     {


### PR DESCRIPTION
The holy is supposed to be 30 cd and not 55.